### PR TITLE
不再使用静态抽象成员

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 本库提供了对与明日方舟相关资源的自定义读取方式。
 
 ## 目标框架
-.NET Standard 2.0, .NET 6 与 .NET 7。
+.NET Standard 2.0。
 
 ## 构建
 .NET CLI 与 Visual Studio 2022皆可。

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 ## 目标框架
 .NET Standard 2.0, .NET 6 与 .NET 7。
 
-### **不同目标框架的差异**
-.NET 7及以上版本的接口定义使用了[静态抽象成员](https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/interface#static-abstract-and-virtual-members)，导致方法签名改变，如果使用了本库，应该考虑使用条件编译等方法避免二进制不兼容。
-
 ## 构建
 .NET CLI 与 Visual Studio 2022皆可。
 

--- a/src/ArknightsResources.CustomResourceHelpers.csproj
+++ b/src/ArknightsResources.CustomResourceHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageTags>Arknights;明日方舟</PackageTags>
@@ -15,9 +15,9 @@
     <Description>Provides basic things for custom resource access.</Description>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsTrimmable>true</IsTrimmable>
-    <Version>0.1.8.0-alpha</Version>
-    <AssemblyVersion>0.1.8.0</AssemblyVersion>
-    <FileVersion>0.1.8.0</FileVersion>
+    <Version>0.1.9.0-alpha</Version>
+    <AssemblyVersion>0.1.9.0</AssemblyVersion>
+    <FileVersion>0.1.9.0</FileVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/Operator/IOperatorIllustrationGetter.cs
+++ b/src/Operator/IOperatorIllustrationGetter.cs
@@ -8,21 +8,6 @@ namespace ArknightsResources.CustomResourceHelpers
     /// </summary>
     public interface IOperatorIllustrationGetter
     {
-#if NET7_0_OR_GREATER
-        /// <summary>
-        /// 通过干员的立绘信息获取其立绘
-        /// </summary>
-        /// <param name="illustInfo">干员的立绘信息</param>
-        /// <returns>一个byte数组,其中包含了干员的立绘</returns>
-        public static abstract byte[] GetOperatorIllustration(OperatorIllustrationInfo illustInfo);
-
-        /// <summary>
-        /// 通过干员的立绘信息异步获取其立绘
-        /// </summary>
-        /// <param name="illustInfo">干员的立绘信息</param>
-        /// <returns>一个byte数组,其中包含了干员的立绘</returns>
-        public static abstract Task<byte[]> GetOperatorIllustrationAsync(OperatorIllustrationInfo illustInfo);
-#else
         /// <summary>
         /// 通过干员的立绘信息获取其立绘
         /// </summary>
@@ -36,6 +21,5 @@ namespace ArknightsResources.CustomResourceHelpers
         /// <param name="illustInfo">干员的立绘信息</param>
         /// <returns>一个byte数组,其中包含了干员的立绘</returns>
         Task<byte[]> GetOperatorIllustrationAsync(OperatorIllustrationInfo illustInfo);
-#endif
     }
 }

--- a/src/Operator/IOperatorInfoGetter.cs
+++ b/src/Operator/IOperatorInfoGetter.cs
@@ -9,53 +9,6 @@ namespace ArknightsResources.CustomResourceHelpers
     /// </summary>
     public interface IOperatorInfoGetter
     {
-#if NET7_0_OR_GREATER
-        /// <summary>
-        /// 通过干员名称获取其<see cref="Operator"/>对象
-        /// </summary>
-        /// <param name="operatorName">干员名称</param>
-        /// <param name="cultureInfo"><see cref="Operator"/>对象所使用的语言</param>
-        /// <returns>一个<see cref="Operator"/>对象</returns>
-        public static abstract Operator GetOperator(string operatorName, CultureInfo cultureInfo);
-
-        /// <summary>
-        /// 通过干员名称异步获取其<see cref="Operator"/>对象
-        /// </summary>
-        /// <param name="operatorName">干员名称</param>
-        /// <param name="cultureInfo"><see cref="Operator"/>对象所使用的语言</param>
-        /// <returns>一个<see cref="Operator"/>对象</returns>
-        public static abstract Task<Operator> GetOperatorAsync(string operatorName, CultureInfo cultureInfo);
-
-        /// <summary>
-        /// 通过干员内部代号获取其<see cref="Operator"/>对象
-        /// </summary>
-        /// <param name="imageCodename">干员内部代号</param>
-        /// <param name="cultureInfo"><see cref="Operator"/>对象所使用的语言</param>
-        /// <returns>一个<see cref="Operator"/>对象</returns>
-        public static abstract Operator GetOperatorWithCodename(string imageCodename, CultureInfo cultureInfo);
-
-        /// <summary>
-        /// 通过干员内部代号异步获取其<see cref="Operator"/>对象
-        /// </summary>
-        /// <param name="imageCodename">干员内部代号</param>
-        /// <param name="cultureInfo"><see cref="Operator"/>对象所使用的语言</param>
-        /// <returns>一个<see cref="Operator"/>对象</returns>
-        public static abstract Task<Operator> GetOperatorWithCodenameAsync(string imageCodename, CultureInfo cultureInfo);
-
-        /// <summary>
-        /// 获取当前可用的全部干员
-        /// </summary>
-        /// <param name="cultureInfo"><see cref="OperatorsList"/>中对象所使用的语言</param>
-        /// <returns>一个<see cref="OperatorsList"/>对象</returns>
-        public static abstract OperatorsList GetAllOperators(CultureInfo cultureInfo);
-
-        /// <summary>
-        /// 异步获取当前可用的全部干员
-        /// </summary>
-        /// <param name="cultureInfo"><see cref="OperatorsList"/>中对象所使用的语言</param>
-        /// <returns>一个<see cref="OperatorsList"/>对象</returns>
-        public static abstract Task<OperatorsList> GetAllOperatorsAsync(CultureInfo cultureInfo);
-#else
         /// <summary>
         /// 通过干员名称获取其<see cref="Operator"/>对象
         /// </summary>
@@ -101,6 +54,5 @@ namespace ArknightsResources.CustomResourceHelpers
         /// <param name="cultureInfo"><see cref="OperatorsList"/>中对象所使用的语言</param>
         /// <returns>一个<see cref="OperatorsList"/>对象</returns>
         Task<OperatorsList> GetAllOperatorsAsync(CultureInfo cultureInfo);
-#endif
     }
 }

--- a/src/Operator/IOperatorSpineAnimationGetter.cs
+++ b/src/Operator/IOperatorSpineAnimationGetter.cs
@@ -1,5 +1,4 @@
-﻿
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using ArknightsResources.Operators.Models;
 
@@ -10,21 +9,6 @@ namespace ArknightsResources.CustomResourceHelpers
     /// </summary>
     public interface IOperatorSpineAnimationGetter
     {
-#if NET7_0_OR_GREATER
-        /// <summary>
-        /// 获取干员的Spine动画
-        /// </summary>
-        /// <param name="spineInfo">干员Spine动画的相关信息</param>
-        /// <returns>一个三元组,第一项为包含atlas信息的<see cref="TextReader"/>,第二项为包含skel信息的<see cref="TextReader"/>,第三项为Spine动画所需的PNG格式图片</returns>
-        public static abstract (TextReader, TextReader, byte[]) GetOperatorSpineAnimation(OperatorSpineInfo spineInfo);
-
-        /// <summary>
-        /// 异步获取干员的Spine动画
-        /// </summary>
-        /// <param name="spineInfo">干员Spine动画的相关信息</param>
-        /// <returns>一个三元组,第一项为包含atlas信息的<see cref="TextReader"/>,第二项为包含skel信息的<see cref="TextReader"/>,第三项为Spine动画所需的PNG格式图片</returns>
-        public static abstract Task<(TextReader, TextReader, byte[])> GetOperatorSpineAnimationAsync(OperatorSpineInfo spineInfo);
-#else
         /// <summary>
         /// 获取干员的Spine动画
         /// </summary>
@@ -38,6 +22,5 @@ namespace ArknightsResources.CustomResourceHelpers
         /// <param name="spineInfo">干员Spine动画的相关信息</param>
         /// <returns>一个三元组,第一项为包含atlas信息的<see cref="TextReader"/>,第二项为包含skel信息的<see cref="TextReader"/>,第三项为Spine动画所需的PNG格式图片</returns>
         Task<(TextReader, TextReader, byte[])> GetOperatorSpineAnimationAsync(OperatorSpineInfo spineInfo);
-#endif
     }
 }

--- a/src/Story/IStoryResourceGetter.cs
+++ b/src/Story/IStoryResourceGetter.cs
@@ -8,39 +8,6 @@ namespace ArknightsResources.CustomResourceHelpers
     /// </summary>
     public interface IStoryResourceGetter
     {
-#if NET7_0_OR_GREATER
-        /// <summary>
-        /// 通过文件代号获取一个剧情视频
-        /// </summary>
-        /// <param name="codename">视频代号</param>
-        /// <param name="cultureInfo">视频所使用的语言,如果视频没有特定的语言,则不必传递CultureInfo</param>
-        /// <returns>包含有视频数据的byte数组</returns>
-        public static abstract byte[] GetVideo(string codename, CultureInfo cultureInfo = null);
-
-        /// <summary>
-        /// 通过文件代号异步获取一个剧情视频
-        /// </summary>
-        /// <param name="codename">视频代号</param>
-        /// <param name="cultureInfo">视频所使用的语言,如果视频没有特定的语言,则不必传递CultureInfo</param>
-        /// <returns>包含有视频数据的byte数组</returns>
-        public static abstract Task<byte[]> GetVideoAsync(string codename, CultureInfo cultureInfo = null);
-
-        /// <summary>
-        /// 通过剧情文件的代号获取该剧情的原始剧情文本
-        /// </summary>
-        /// <param name="codename">剧情文件的代号</param>
-        /// <param name="cultureInfo"></param>
-        /// <returns>原始剧情文本</returns>
-        public static abstract string GetStoryRawText(string codename, CultureInfo cultureInfo);
-
-        /// <summary>
-        /// 通过剧情文件的代号异步获取该剧情的原始剧情文本
-        /// </summary>
-        /// <param name="codename">剧情文件的代号</param>
-        /// <param name="cultureInfo"></param>
-        /// <returns>原始剧情文本</returns>
-        public static abstract Task<string> GetStoryRawTextAsync(string codename, CultureInfo cultureInfo);
-#else
         /// <summary>
         /// 通过文件代号获取一个剧情视频
         /// </summary>
@@ -72,6 +39,5 @@ namespace ArknightsResources.CustomResourceHelpers
         /// <param name="cultureInfo"></param>
         /// <returns>原始剧情文本</returns>
         Task<string> GetStoryRawTextAsync(string codename, CultureInfo cultureInfo);
-#endif
     }
 }


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
💥不再使用静态抽象成员，不再面向.NET 6+
🔖0.1.9.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
- 其他，请描述内容：设计更改

## 当前行为是什么？
.NET 7 及以上版本的库使用静态抽象成员，并且具有多目标
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
使用静态抽象成员，并且目标只面向.NET Standard 2.0
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注
不再使用静态抽象成员的原因是：低版本的框架无法使用包含静态抽象成员的方法，而且静态抽象成员可能在某些情况缺少灵活性
<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->