### PR TITLE
不再使用OperatorsList类

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -5,21 +5,11 @@ on:
   push:
     branches: [ main ]
 
-env:
-  DOTNET_VERSION: '7.x' # The .NET SDK version to use
-
 jobs:
   build:
 
     name: Build and pack
     runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Add NuGet Source
       run: dotnet nuget add source --username ArknightsResources --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/ArknightsResources/index.json"

--- a/src/ArknightsResources.CustomResourceHelpers.csproj
+++ b/src/ArknightsResources.CustomResourceHelpers.csproj
@@ -15,9 +15,9 @@
     <Description>Provides basic things for custom resource access.</Description>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsTrimmable>true</IsTrimmable>
-    <Version>0.1.10.0-alpha</Version>
-    <AssemblyVersion>0.1.10.0</AssemblyVersion>
-    <FileVersion>0.1.10.0</FileVersion>
+    <Version>0.2.0.0-alpha</Version>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -36,10 +36,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArknightsResources.Operators.Models" Version="0.1.6-alpha" />
+    <PackageReference Include="ArknightsResources.Operators.Models" Version="0.2.0-alpha" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Operator/IOperatorIllustrationGetter.cs
+++ b/src/Operator/IOperatorIllustrationGetter.cs
@@ -4,7 +4,7 @@ using ArknightsResources.Operators.Models;
 namespace ArknightsResources.CustomResourceHelpers
 {
     /// <summary>
-    /// 定义一套用以读取与干员立绘相关资源的方法
+    /// 定义一套读取干员立绘相关资源的方法
     /// </summary>
     public interface IOperatorIllustrationGetter
     {

--- a/src/Operator/IOperatorInfoGetter.cs
+++ b/src/Operator/IOperatorInfoGetter.cs
@@ -1,11 +1,12 @@
-﻿using System.Globalization;
+﻿using System.Collections.Immutable;
+using System.Globalization;
 using System.Threading.Tasks;
 using ArknightsResources.Operators.Models;
 
 namespace ArknightsResources.CustomResourceHelpers
 {
     /// <summary>
-    /// 定义一套用以获取与干员相关信息的方法
+    /// 定义获取干员相关信息的方法
     /// </summary>
     public interface IOperatorInfoGetter
     {
@@ -44,15 +45,15 @@ namespace ArknightsResources.CustomResourceHelpers
         /// <summary>
         /// 获取当前可用的全部干员
         /// </summary>
-        /// <param name="cultureInfo"><see cref="OperatorsList"/>中对象所使用的语言</param>
-        /// <returns>一个<see cref="OperatorsList"/>对象</returns>
-        OperatorsList GetAllOperators(CultureInfo cultureInfo);
+        /// <param name="cultureInfo"><see cref="Operator"/>对象所使用的语言</param>
+        /// <returns>一个Key为干员代号，Value为<see cref="Operator"/>对象的字典</returns>
+        ImmutableDictionary<string, Operator> GetAllOperators(CultureInfo cultureInfo);
 
         /// <summary>
         /// 异步获取当前可用的全部干员
         /// </summary>
-        /// <param name="cultureInfo"><see cref="OperatorsList"/>中对象所使用的语言</param>
-        /// <returns>一个<see cref="OperatorsList"/>对象</returns>
-        Task<OperatorsList> GetAllOperatorsAsync(CultureInfo cultureInfo);
+        /// <param name="cultureInfo"><see cref="Operator"/>对象所使用的语言</param>
+        /// <returns>一个Key为干员代号，Value为<see cref="Operator"/>对象的字典</returns>
+        Task<ImmutableDictionary<string, Operator>> GetAllOperatorsAsync(CultureInfo cultureInfo);
     }
 }

--- a/src/Operator/IOperatorSpineAnimationGetter.cs
+++ b/src/Operator/IOperatorSpineAnimationGetter.cs
@@ -5,7 +5,7 @@ using ArknightsResources.Operators.Models;
 namespace ArknightsResources.CustomResourceHelpers
 {
     /// <summary>
-    /// 定义一套用以读取与干员Spine动画相关资源的方法
+    /// 定义一套读取干员Spine动画相关资源的方法
     /// </summary>
     public interface IOperatorSpineAnimationGetter
     {

--- a/src/Operator/IOperatorVoiceGetter.cs
+++ b/src/Operator/IOperatorVoiceGetter.cs
@@ -9,14 +9,14 @@ namespace ArknightsResources.CustomResourceHelpers
     public interface IOperatorVoiceGetter
     {
         /// <summary>
-        /// 通过干员的配音信息获取其语音
+        /// 通过干员的语音信息获取其语音
         /// </summary>
         /// <param name="voiceInfo"></param>
         /// <returns></returns>
         byte[] GetOperatorVoice(OperatorVoiceItem voiceInfo);
 
         /// <summary>
-        /// 通过干员的配音信息异步获取其语音
+        /// 通过干员的语音信息异步获取其语音
         /// </summary>
         /// <param name="voiceInfo"></param>
         /// <returns></returns>

--- a/src/Story/IStoryResourceGetter.cs
+++ b/src/Story/IStoryResourceGetter.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace ArknightsResources.CustomResourceHelpers
 {
     /// <summary>
-    /// 定义一套用以读取与剧情相关资源的方法
+    /// 定义一套读取剧情相关资源的方法
     /// </summary>
     public interface IStoryResourceGetter
     {


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
💥弃用OperatorsList类，改为使用ImmutableDictionary
➕System.Collections.Immutable
💬修订文档注释
👷CI过程不再安装.NET 7 SDK
🔖0.2.0.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
- 其他，请描述内容： 弃用OperatorsList类

## 当前行为是什么？
IOperatorInfoGetter.GetAllOperators仍然返回上游库不再支持的OperatorsList
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
IOperatorInfoGetter.GetAllOperators改为返回BCL的ImmutableDictionary
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注
接口实现者应该返回ImmutableDictionary而不是返回OperatorsList
<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->